### PR TITLE
Limit social logins based on tenant.

### DIFF
--- a/allauth_office365/views.py
+++ b/allauth_office365/views.py
@@ -13,8 +13,8 @@ from .provider import Office365Provider
 
 class Office365OAuth2Adapter(OAuth2Adapter):
     provider_id = Office365Provider.id
-    authorize_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
-    access_token_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+    _authorize_url_template = 'https://login.microsoftonline.com/{TENANT}/oauth2/v2.0/authorize'
+    _access_token_url_template = 'https://login.microsoftonline.com/{TENANT}/oauth2/v2.0/token'
     profile_url = 'https://graph.microsoft.com/v1.0/me'
 
     def complete_login(self, request, app, token, **kwargs):
@@ -23,6 +23,26 @@ class Office365OAuth2Adapter(OAuth2Adapter):
         extra_data = resp.json()
         return self.get_provider().sociallogin_from_response(request,
                                                              extra_data)
+
+    def _get_o365_tenant(self):
+        # https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints        
+        """ 
+        Available tenant values: common, organizations, consumers, contoso.onmicrosoft.com.
+        """        
+        from allauth.socialaccount import app_settings
+        _settings = app_settings.PROVIDERS.get(self.get_provider().id, {})
+        return _settings.get('TENANT', 'common')
+
+    @property
+    def authorize_url(self):        
+        """Define the tenant's available for SocialLogin authorize (common, organizations, consumers, contoso.onmicrosoft.com)"""
+        return self._authorize_url_template.format(TENANT=self._get_o365_tenant())
+
+    @property
+    def access_token_url(self):
+        """Define the tenant's available for SocialLogin token (common, organizations, consumers, contoso.onmicrosoft.com)"""
+        return self._access_token_url_template.format(TENANT=self._get_o365_tenant())
+
 
 oauth2_login = OAuth2LoginView.adapter_view(Office365OAuth2Adapter)
 oauth2_callback = OAuth2CallbackView.adapter_view(Office365OAuth2Adapter)


### PR DESCRIPTION
Needed the ability to limit social logins to my company. [MS graph offers this with the tenant value used in the authorize and token urls. 
](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints) https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints

Available tenant values: common, organizations, consumers, contoso.onmicrosoft.com/organization's id.

If a user tries to login in with incorrect tenant (for instances: "consumers" account trying to login to "organizations") Office365 login will fail and the Office365 login page will display an error. Leaving it up to the django project to let the user know if it limits login's.
